### PR TITLE
Update Installation.rst

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -161,7 +161,7 @@ To test the core functionality of TEPIC, go to the folder::
    
 and run the example with the command:::
 
-  ./TEPIC.sh -g ../Test/example_sequence.fa -b ../Test/example_regions.bed -o TEPIC-Example -p ../PWMs/pwm_vertebrates_jaspar_uniprobe_original.PSEM -a ../Test/example_annotation.gtf -w 3000 -e FALSE
+  ./TEPIC.sh -g ../Test/example_sequence.fa -b ../Test/example_regions.bed -o TEPIC-Example -p ../PWMs/1.0/pwm_vertebrates_jaspar_uniprobe_original.PSEM -a ../Test/example_annotation.gtf -w 3000 -e FALSE
 
 There should be three result files generated:
 


### PR DESCRIPTION
PWM file required for test has been moved, and hence the test run of TEPIC was failing. This change fixes it.